### PR TITLE
chore: リリースワークフローの更新と削除ファイルのgitattributesからの削除

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.github                    export-ignore
 /.gitignore                 export-ignore
 /Tests                      export-ignore
+/doc                        export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /.gitattributes             export-ignore
 /.github                    export-ignore
 /.gitignore                 export-ignore
+/Tests                      export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,23 @@
-
 name: Packaging for EC-CUBE Plugin
+
 on:
   release:
     types: [ published ]
+
 jobs:
   deploy:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+
       - name: Packaging
         run: |
           git archive HEAD --format=tar.gz > ../${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz
+
       - name: Upload binaries to release of TGZ
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ runner.workspace }}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.tar.gz


### PR DESCRIPTION
- release.ymlのGitHub Actionsバージョンを更新（checkout@v6, upload-release-action@v2）
- .gitattributesから改善項目.mdのexport-ignore設定を削除